### PR TITLE
chore: add netlify config file to expose cors headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Including the built file in a script tag can lead to a CORS issue. This should fix this and allow us to slap an integrity hash on it.

**Verification this works...**
![image](https://user-images.githubusercontent.com/9825605/140417268-26d25a7e-0818-402e-9723-f70d12ee06d0.png)

**Current result...**
![image](https://user-images.githubusercontent.com/9825605/140417338-541c8926-557b-4a77-a532-012954fbb8dd.png)

